### PR TITLE
implement the simplest possible encoder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: ginkgo -race -cover -v -randomizeAllSpecs
       - run:
           name: "Run integration tests"
-          command: ginkgo -race -v -randomizeAllSpecs -trace integrationtests
+          command: ginkgo -r -race -v -randomizeAllSpecs -trace integrationtests
       - run:
           name: "Upload coverage report to Codecov"
           when: on_success

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "integrationtests/qifs"]
-	path = integrationtests/qifs
+[submodule "integrationtests/interop/qifs"]
+	path = integrationtests/interop/qifs
 	url = git@github.com:qpackers/qifs.git

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ git submodule update --init --recursive
 
 Then run the tests:
 ```bash
-ginkgo integrationtests
+ginkgo -r integrationtests
 ```

--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,40 @@
+package qpack
+
+import (
+	"io"
+)
+
+// An Encoder performs QPACK encoding.
+type Encoder struct {
+	w   io.Writer
+	buf []byte
+}
+
+// NewEncoder returns a new Encoder which performs QPACK encoding. An
+// encoded data is written to w.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w: w}
+}
+
+// WriteField encodes f into a single Write to e's underlying Writer.
+// This function may also produce bytes for the Header Block Prefix
+// if necessary. If produced, it is done before encoding f.
+func (e *Encoder) WriteField(f HeaderField) error {
+	// write the Header Block Prefix
+	e.buf = appendVarInt(e.buf, 8, 0)
+	e.buf = appendVarInt(e.buf, 7, 0)
+
+	e.writeLiteralFieldWithoutNameReference(f)
+	e.w.Write(e.buf)
+	e.buf = e.buf[:0]
+	return nil
+}
+
+func (e *Encoder) writeLiteralFieldWithoutNameReference(f HeaderField) {
+	offset := len(e.buf)
+	e.buf = appendVarInt(e.buf, 3, uint64(len(f.Name)))
+	e.buf[offset] ^= 0x20
+	e.buf = append(e.buf, []byte(f.Name)...)
+	e.buf = appendVarInt(e.buf, 7, uint64(len(f.Value)))
+	e.buf = append(e.buf, []byte(f.Value)...)
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,50 @@
+package qpack
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Encoder", func() {
+	var (
+		encoder *Encoder
+		output  *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		output = &bytes.Buffer{}
+		encoder = NewEncoder(output)
+	})
+
+	readPrefix := func(data []byte) (rest []byte, requiredInsertCount uint64, deltaBase uint64) {
+		var err error
+		requiredInsertCount, rest, err = readVarInt(8, data)
+		Expect(err).ToNot(HaveOccurred())
+		deltaBase, rest, err = readVarInt(7, rest)
+		Expect(err).ToNot(HaveOccurred())
+		return
+	}
+
+	It("encodes", func() {
+		hf := HeaderField{Name: "foobar", Value: "lorem ipsum"}
+		Expect(encoder.WriteField(hf)).To(Succeed())
+
+		data, requiredInsertCount, deltaBase := readPrefix(output.Bytes())
+		Expect(requiredInsertCount).To(BeZero())
+		Expect(deltaBase).To(BeZero())
+
+		Expect(data[0] & (0x80 ^ 0x40 ^ 0x20)).To(Equal(uint8(0x20))) // 001xxxxx
+		Expect(data[0] & 0x8).To(BeZero())                            // no Huffman encoding
+		nameLen, data, err := readVarInt(3, data)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nameLen).To(BeEquivalentTo(6))
+		Expect(string(data[:6])).To(Equal("foobar"))
+		valueLen, data, err := readVarInt(7, data[6:])
+		Expect(err).ToNot(HaveOccurred())
+		Expect(valueLen).To(BeEquivalentTo(11))
+		Expect(string(data[:11])).To(Equal("lorem ipsum"))
+		Expect(data[11:]).To(BeEmpty())
+	})
+})

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -27,7 +27,21 @@ var _ = Describe("Encoder", func() {
 		return
 	}
 
-	It("encodes", func() {
+	checkHeaderField := func(data []byte, hf HeaderField) []byte {
+		Expect(data[0] & (0x80 ^ 0x40 ^ 0x20)).To(Equal(uint8(0x20))) // 001xxxxx
+		Expect(data[0] & 0x8).To(BeZero())                            // no Huffman encoding
+		nameLen, data, err := readVarInt(3, data)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nameLen).To(BeEquivalentTo(len(hf.Name)))
+		Expect(string(data[:len(hf.Name)])).To(Equal(hf.Name))
+		valueLen, data, err := readVarInt(7, data[len(hf.Name):])
+		Expect(err).ToNot(HaveOccurred())
+		Expect(valueLen).To(BeEquivalentTo(len(hf.Value)))
+		Expect(string(data[:len(hf.Value)])).To(Equal(hf.Value))
+		return data[len(hf.Value):]
+	}
+
+	It("encodes a single field", func() {
 		hf := HeaderField{Name: "foobar", Value: "lorem ipsum"}
 		Expect(encoder.WriteField(hf)).To(Succeed())
 
@@ -35,16 +49,42 @@ var _ = Describe("Encoder", func() {
 		Expect(requiredInsertCount).To(BeZero())
 		Expect(deltaBase).To(BeZero())
 
-		Expect(data[0] & (0x80 ^ 0x40 ^ 0x20)).To(Equal(uint8(0x20))) // 001xxxxx
-		Expect(data[0] & 0x8).To(BeZero())                            // no Huffman encoding
-		nameLen, data, err := readVarInt(3, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(nameLen).To(BeEquivalentTo(6))
-		Expect(string(data[:6])).To(Equal("foobar"))
-		valueLen, data, err := readVarInt(7, data[6:])
-		Expect(err).ToNot(HaveOccurred())
-		Expect(valueLen).To(BeEquivalentTo(11))
-		Expect(string(data[:11])).To(Equal("lorem ipsum"))
-		Expect(data[11:]).To(BeEmpty())
+		data = checkHeaderField(data, hf)
+		Expect(data).To(BeEmpty())
+	})
+
+	It("encodes multipe fields", func() {
+		hf1 := HeaderField{Name: "foobar", Value: "lorem ipsum"}
+		hf2 := HeaderField{Name: "raboof", Value: "dolor sit amet"}
+		Expect(encoder.WriteField(hf1)).To(Succeed())
+		Expect(encoder.WriteField(hf2)).To(Succeed())
+
+		data, requiredInsertCount, deltaBase := readPrefix(output.Bytes())
+		Expect(requiredInsertCount).To(BeZero())
+		Expect(deltaBase).To(BeZero())
+
+		data = checkHeaderField(data, hf1)
+		data = checkHeaderField(data, hf2)
+		Expect(data).To(BeEmpty())
+	})
+
+	It("encodes multiple requests", func() {
+		hf1 := HeaderField{Name: "foobar", Value: "lorem ipsum"}
+		Expect(encoder.WriteField(hf1)).To(Succeed())
+		data, requiredInsertCount, deltaBase := readPrefix(output.Bytes())
+		Expect(requiredInsertCount).To(BeZero())
+		Expect(deltaBase).To(BeZero())
+		data = checkHeaderField(data, hf1)
+		Expect(data).To(BeEmpty())
+
+		output.Reset()
+		Expect(encoder.Close())
+		hf2 := HeaderField{Name: "raboof", Value: "dolor sit amet"}
+		Expect(encoder.WriteField(hf2)).To(Succeed())
+		data, requiredInsertCount, deltaBase = readPrefix(output.Bytes())
+		Expect(requiredInsertCount).To(BeZero())
+		Expect(deltaBase).To(BeZero())
+		data = checkHeaderField(data, hf2)
+		Expect(data).To(BeEmpty())
 	})
 })

--- a/integrationtests/interop/interop_suite_test.go
+++ b/integrationtests/interop/interop_suite_test.go
@@ -1,4 +1,4 @@
-package integrationtests
+package interop
 
 import (
 	"bufio"
@@ -13,9 +13,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestIntegrationtests(t *testing.T) {
+func TestInterop(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Integration Tests Suite")
+	RunSpecs(t, "Interop Suite")
 }
 
 type request struct {

--- a/integrationtests/interop/interop_test.go
+++ b/integrationtests/interop/interop_test.go
@@ -1,4 +1,4 @@
-package integrationtests
+package interop
 
 import (
 	"encoding/binary"

--- a/integrationtests/self/integration_test.go
+++ b/integrationtests/self/integration_test.go
@@ -1,0 +1,38 @@
+package self
+
+import (
+	"bytes"
+
+	"github.com/marten-seemann/qpack"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Self Tests", func() {
+	var (
+		// for the encoder
+		output  *bytes.Buffer
+		encoder *qpack.Encoder
+		// for the decoder
+		headerFields []qpack.HeaderField
+		decoder      *qpack.Decoder
+	)
+
+	BeforeEach(func() {
+		output = &bytes.Buffer{}
+		encoder = qpack.NewEncoder(output)
+		headerFields = nil
+		decoder = qpack.NewDecoder(func(hf qpack.HeaderField) {
+			headerFields = append(headerFields, hf)
+		})
+	})
+
+	It("encodes and decodes a single header", func() {
+		hf := qpack.HeaderField{Name: "foo", Value: "bar"}
+		Expect(encoder.WriteField(hf)).To(Succeed())
+		_, err := decoder.Write(output.Bytes())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(headerFields).To(Equal([]qpack.HeaderField{hf}))
+	})
+})

--- a/integrationtests/self/self_suite_test.go
+++ b/integrationtests/self/self_suite_test.go
@@ -1,0 +1,13 @@
+package self
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSelf(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Self Suite")
+}


### PR DESCRIPTION
It doesn't use the static table, it just sends string literals for both header names and header values. Furthermore, it doesn't use Huffman encoding.