### PR TITLE
return write error when encoding header fields

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -51,9 +51,9 @@ func (e *Encoder) WriteField(f HeaderField) error {
 		e.writeLiteralFieldWithoutNameReference(f)
 	}
 
-	e.w.Write(e.buf)
+	_, err := e.w.Write(e.buf)
 	e.buf = e.buf[:0]
-	return nil
+	return err
 }
 
 // Close declares that the encoding is complete and resets the Encoder


### PR DESCRIPTION
The encoder does not check for errors when writing the header field. But since the underlying transform for Encoder is a generic io.Writer, we need to check for any issues there and propagate them.